### PR TITLE
Fix handling of attributes with empty keys in logHandler.Handle

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -149,6 +149,26 @@ func TestHandle(t *testing.T) {
 				"error message",
 			},
 		},
+		{
+			name: "info level with empty key attr",
+			record: slog.Record{
+				Time:    testTime,
+				Level:   slog.LevelInfo,
+				Message: "message with empty key",
+			},
+			color: false,
+			attrs: []slog.Attr{
+				{Key: "", Value: slog.StringValue("no key")},
+				slog.String("key1", "value1"),
+			},
+			wantContains: []string{
+				"2023-01-02T15:04:05.000Z",
+				"[INFO]",
+				"[no key]",
+				"[key1:value1]",
+				"message with empty key",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -74,7 +74,11 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 		buf.Write(h.preformatted)
 	}
 	record.Attrs(func(a slog.Attr) bool {
-		fprintf(buf, " [%s:%v]", a.Key, a.Value)
+		if a.Key == "" {
+			fprintf(buf, " [%v]", a.Value)
+		} else {
+			fprintf(buf, " [%s:%v]", a.Key, a.Value)
+		}
 		return true
 	})
 	fprintf(buf, " %s\n", record.Message)


### PR DESCRIPTION
When an attribute with an empty key is encountered, format it as [value] instead of [:value] for better readability.