### PR TITLE
Reduce escape seq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 .envrc
+
+**/.claude/settings.local.json

--- a/handler_test.go
+++ b/handler_test.go
@@ -97,7 +97,7 @@ func TestFprintfFunc(t *testing.T) {
 			Color:          tt.color,
 		}
 		handler := NewLogHandler(buf, opts).(*logHandler)
-		f := handler.FprintfFunc(tt.level)
+		f := handler.FprintFunc(tt.level)
 		if f == nil {
 			t.Errorf("FprintfFunc(%v, color=%v) returned nil", tt.level, tt.color)
 		}
@@ -115,11 +115,11 @@ func TestHandle(t *testing.T) {
 	testTime := time.Date(2023, 1, 2, 15, 4, 5, 0, time.UTC)
 
 	tests := []struct {
-		name         string
-		record       slog.Record
-		color        bool
-		attrs        []slog.Attr
-		wantContains []string
+		name            string
+		record          slog.Record
+		color           bool
+		attrs           []slog.Attr
+		wantContains    []string
 		wantNotContains []string
 	}{
 		{
@@ -350,12 +350,12 @@ func TestWithGroup(t *testing.T) {
 	}
 }
 
-func TestFprintfFuncOutput(t *testing.T) {
+func TestFprintFuncOutput(t *testing.T) {
 	tests := []struct {
-		name         string
-		level        slog.Level
-		color        bool
-		wantContains []string
+		name            string
+		level           slog.Level
+		color           bool
+		wantContains    []string
 		wantNotContains []string
 	}{
 		{
@@ -432,7 +432,7 @@ func TestFprintfFuncOutput(t *testing.T) {
 				Color:          tt.color,
 			}
 			handler := NewLogHandler(buf, opts).(*logHandler)
-			fprintfFunc := handler.FprintfFunc(tt.level)
+			fprintfFunc := handler.FprintFunc(tt.level)
 
 			// Call the function to write to buffer
 			fprintfFunc(buf, "test message")


### PR DESCRIPTION
This pull request introduces enhancements and refactoring to improve color handling in logging functionality, alongside updates to related tests. The changes focus on ensuring better test coverage for colorized and non-colorized log outputs, as well as simplifying the implementation of color formatting.

### Refactoring and Improvements to Logging Functionality:
* Renamed `FprintfFunc` to `FprintFunc` in `main.go` for consistency and removed unnecessary format strings from the default logging function. (`[[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L21-R24)`, `[[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L52-R100)`)
* Refactored the `Handle` method to apply color formatting only once at the end of the log message generation, improving efficiency. (`[main.goL52-R100](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L52-R100)`)

### Enhancements to Test Coverage:
* Added new test cases in `handler_test.go` to verify colorized and non-colorized log outputs for different log levels, including debug, info, warn, and error. (`[[1]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR185-R238)`, `[[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR353-R460)`)
* Introduced `wantNotContains` checks in tests to ensure that specific ANSI escape sequences are absent when color is disabled. (`[[1]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR123)`, `[[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR139-R141)`, `[[3]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR162-R164)`)
* Added an integration test to validate the behavior of the logger with color enabled for different log levels. (`[handler_test.goR506-R568](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR506-R568)`)

### Minor Adjustments:
* Updated the `init` function in `handler_test.go` to force-enable colors during testing for consistent test results. (`[handler_test.goR9-R17](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR9-R17)`)