### PR TITLE
All levels coloring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It provides colored text output with customizable formatting and metrics integra
 ## Features
 
 - Simple, readable text output format
-- Colorized output for warning and error levels
+- Colorized output for all log levels (customizable)
 - Preservation of log attributes
 - Metrics integration: Export log volume and level metrics to monitoring systems
   - `prommetrics`: Prometheus metrics handler for tracking log statistics
@@ -47,8 +47,8 @@ func main() {
 	slog.SetDefault(logger)
 
 	// Basic usage
-	slog.Debug("This is a debug message")
-	slog.Info("This is an info message")
+	slog.Debug("This is a debug message")  // Gray output
+	slog.Info("This is an info message")   // No color by default
 	slog.Warn("This is a warning message") // Yellow output
 	slog.Error("This is an error message") // Red output
 
@@ -74,16 +74,39 @@ Output format:
 
 ## Customization
 
+### Color Configuration
+
+By default, log messages are colored as follows when `Color: true` is set:
+- **DEBUG**: Gray (dark gray)
+- **INFO**: No color (can be customized)
+- **WARN**: Yellow
+- **ERROR**: Red
+
 You can customize the time format and colors:
 
 ```go
+import "github.com/fatih/color"
+
 // Customize time format
 sloghandler.TimeFormat = "2006/01/02 15:04:05"
 
 // Customize colors
+sloghandler.DebugColor = color.FgCyan
+sloghandler.InfoColor = color.FgBlue  // Set color for INFO level
 sloghandler.WarnColor = color.FgMagenta
 sloghandler.ErrorColor = color.FgHiRed
+
+// To disable INFO color (back to default)
+sloghandler.InfoColor = 0
 ```
+
+### Global Variables
+
+- `TimeFormat string`: Customize the timestamp format (default: RFC3339 with milliseconds)
+- `DebugColor color.Attribute`: Color for debug messages (default: gray)
+- `InfoColor color.Attribute`: Color for info messages (default: 0 = no color)
+- `WarnColor color.Attribute`: Color for warning messages (default: yellow)
+- `ErrorColor color.Attribute`: Color for error messages (default: red)
 
 ---
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -385,9 +385,8 @@ func TestFprintFuncOutput(t *testing.T) {
 			color: true,
 			wantContains: []string{
 				"test message",
-			},
-			wantNotContains: []string{
-				"\033[", // No color for debug
+				"\033[", // Should have escape sequence
+				"m",     // Color code terminator
 			},
 		},
 		{
@@ -540,9 +539,9 @@ func TestIntegrationWithColor(t *testing.T) {
 	if !bytes.Contains(buf.Bytes(), []byte("debug message")) {
 		t.Errorf("Logger.Debug() output doesn't contain message, got: %s", output)
 	}
-	// Debug should not have color
-	if bytes.Contains(buf.Bytes(), []byte("\033[")) {
-		t.Errorf("Logger.Debug() output should not contain ANSI escape sequence, got: %s", output)
+	// Debug should have color
+	if !bytes.Contains(buf.Bytes(), []byte("\033[")) {
+		t.Errorf("Logger.Debug() output should contain ANSI escape sequence, got: %s", output)
 	}
 
 	// Reset buffer

--- a/main.go
+++ b/main.go
@@ -12,10 +12,24 @@ import (
 )
 
 var (
+	// TimeFormat defines the timestamp format used in log output.
+	// Default is RFC3339 with milliseconds.
 	TimeFormat = "2006-01-02T15:04:05.000Z07:00"
+	
+	// DebugColor defines the color attribute for DEBUG level messages.
+	// Default is dark gray (color.FgHiBlack).
 	DebugColor = color.FgHiBlack
-	InfoColor  color.Attribute // 0 by default (no color)
-	WarnColor  = color.FgYellow
+	
+	// InfoColor defines the color attribute for INFO level messages.
+	// Default is 0 (no color). Set to a color.Attribute value to enable coloring.
+	InfoColor color.Attribute
+	
+	// WarnColor defines the color attribute for WARN level messages.
+	// Default is yellow (color.FgYellow).
+	WarnColor = color.FgYellow
+	
+	// ErrorColor defines the color attribute for ERROR level messages.
+	// Default is red (color.FgRed).
 	ErrorColor = color.FgRed
 )
 
@@ -28,8 +42,11 @@ var (
 	}
 )
 
+// HandlerOptions extends slog.HandlerOptions with additional formatting options.
 type HandlerOptions struct {
 	slog.HandlerOptions
+	// Color enables colored output based on log level when set to true.
+	// Colors can be customized using the global color variables.
 	Color bool
 }
 
@@ -40,6 +57,9 @@ type logHandler struct {
 	w            io.Writer
 }
 
+// NewLogHandler creates a new log handler that writes formatted log messages to w.
+// The handler supports colored output when opts.Color is true, with customizable
+// colors for each log level via global color variables.
 func NewLogHandler(w io.Writer, opts *HandlerOptions) slog.Handler {
 	return &logHandler{
 		opts: opts,

--- a/main.go
+++ b/main.go
@@ -13,11 +13,14 @@ import (
 
 var (
 	TimeFormat = "2006-01-02T15:04:05.000Z07:00"
+	DebugColor = color.FgHiBlack
+	InfoColor  color.Attribute // 0 by default (no color)
 	WarnColor  = color.FgYellow
 	ErrorColor = color.FgRed
 )
 
 var (
+	debugColoredFprintFunc = color.New(DebugColor).FprintFunc()
 	warnColoredFprintFunc  = color.New(WarnColor).FprintFunc()
 	errorColoredFprintFunc = color.New(ErrorColor).FprintFunc()
 	defaultFprintFunc      = func(w io.Writer, args ...interface{}) {
@@ -53,9 +56,11 @@ func (h *logHandler) FprintFunc(level slog.Level) func(io.Writer, ...interface{}
 	if h.opts.Color {
 		switch level {
 		case slog.LevelDebug:
-			// no color
+			return debugColoredFprintFunc
 		case slog.LevelInfo:
-			// no color
+			if InfoColor != 0 {
+				return color.New(InfoColor).FprintFunc()
+			}
 		case slog.LevelWarn:
 			return warnColoredFprintFunc
 		case slog.LevelError:


### PR DESCRIPTION
This pull request introduces customizable colorized output for log levels, enhances the documentation to reflect these changes, and updates the test cases to validate the new functionality. The key changes include adding global color configuration variables, updating the log handler to support these customizations, and modifying the test cases to ensure correct behavior.

### Colorized Output Enhancements:
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R15-R49): Added global variables (`DebugColor`, `InfoColor`, `WarnColor`, `ErrorColor`) to define default and customizable colors for log levels. Updated the `FprintFunc` method in `logHandler` to use these variables for colorized output. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R15-R49) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L56-R83)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R77-R110): Updated the documentation to include a new "Color Configuration" section, explaining default colors and how to customize them. Examples for setting colors and disabling them were added.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9): Updated the feature list to reflect colorized output for all log levels. Clarified the default behavior for `Debug` and `Info` messages in the usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R51)

### Test Case Updates:
* [`handler_test.go`](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL388-R389): Updated test cases to validate the presence of ANSI escape sequences for colorized output in `DEBUG` and other log levels. Removed checks asserting the absence of color for `DEBUG`. [[1]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL388-R389) [[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL543-R544)