### PR TITLE
Add Source and SourceDepth options for source location display

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
         go:
           - '1.23'
           - '1.24'
+          - '1.25'
     name: Build
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It provides colored text output with customizable formatting and metrics integra
 
 - Simple, readable text output format
 - Colorized output for all log levels (customizable)
+- Source file location display with configurable depth
 - Preservation of log attributes
 - Metrics integration: Export log volume and level metrics to monitoring systems
   - `prommetrics`: Prometheus metrics handler for tracking log statistics
@@ -73,6 +74,35 @@ Output format:
 ```
 
 ## Customization
+
+### Source Location
+
+You can display source file location (filename and line number) in log output:
+
+```go
+opts := &sloghandler.HandlerOptions{
+	HandlerOptions: slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	},
+	Source: true,      // Enable source file display
+	SourceDepth: 1,    // Include parent directory (e.g., "pkg/main.go")
+}
+handler := sloghandler.NewLogHandler(os.Stdout, opts)
+```
+
+Output:
+
+```
+2023-05-09T12:34:56.789+09:00 [INFO] [main.go:42] Server started
+2023-05-09T12:34:56.790+09:00 [INFO] [pkg/server.go:15] Listening for connections
+```
+
+#### SourceDepth Options
+
+- `0` (default): Show filename only (`main.go`)
+- `1`: Show parent directory and filename (`pkg/main.go`)
+- `2`: Show two levels (`src/pkg/main.go`)
+- etc.
 
 ### Color Configuration
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ type logHandler struct {
 	preformatted []byte
 	mu           *sync.Mutex
 	w            io.Writer
-	sourceCache  sync.Map // Cache for source location
+	sourceCache  sync.Map // Cache for formatted source file paths, keyed by path and depth
 }
 
 // NewLogHandler creates a new log handler that writes formatted log messages to w.

--- a/main.go
+++ b/main.go
@@ -15,19 +15,19 @@ var (
 	// TimeFormat defines the timestamp format used in log output.
 	// Default is RFC3339 with milliseconds.
 	TimeFormat = "2006-01-02T15:04:05.000Z07:00"
-	
+
 	// DebugColor defines the color attribute for DEBUG level messages.
 	// Default is dark gray (color.FgHiBlack).
 	DebugColor = color.FgHiBlack
-	
+
 	// InfoColor defines the color attribute for INFO level messages.
 	// Default is 0 (no color). Set to a color.Attribute value to enable coloring.
 	InfoColor color.Attribute
-	
+
 	// WarnColor defines the color attribute for WARN level messages.
 	// Default is yellow (color.FgYellow).
 	WarnColor = color.FgYellow
-	
+
 	// ErrorColor defines the color attribute for ERROR level messages.
 	// Default is red (color.FgRed).
 	ErrorColor = color.FgRed
@@ -47,7 +47,12 @@ type HandlerOptions struct {
 	slog.HandlerOptions
 	// Color enables colored output based on log level when set to true.
 	// Colors can be customized using the global color variables.
-	Color bool
+	Color  bool
+	Source bool
+	// SourceDepth controls the number of parent directories to include in source file paths.
+	// Default is 0 (filename only). Set to 1 for parent/file.go, 2 for grandparent/parent/file.go, etc.
+	// Negative values default to 0.
+	SourceDepth int
 }
 
 type logHandler struct {
@@ -55,6 +60,7 @@ type logHandler struct {
 	preformatted []byte
 	mu           *sync.Mutex
 	w            io.Writer
+	sourceCache  sync.Map // Cache for source location
 }
 
 // NewLogHandler creates a new log handler that writes formatted log messages to w.
@@ -99,6 +105,10 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 
 	if len(h.preformatted) > 0 {
 		buf.Write(h.preformatted)
+	}
+
+	if h.opts.Source {
+		h.printSource(buf, record)
 	}
 
 	record.Attrs(func(a slog.Attr) bool {

--- a/source.go
+++ b/source.go
@@ -1,12 +1,16 @@
 package sloghandler
 
 import (
-	"fmt"
 	"path/filepath"
 )
 
+type sourceCacheKey struct {
+	path  string
+	depth int
+}
+
 func (h *logHandler) getFilePath(path string) []byte {
-	cacheKey := fmt.Sprintf("%s:%d", path, h.opts.SourceDepth)
+	cacheKey := sourceCacheKey{path: path, depth: h.opts.SourceDepth}
 	if cached, ok := h.sourceCache.Load(cacheKey); ok {
 		return cached.([]byte)
 	}

--- a/source.go
+++ b/source.go
@@ -1,0 +1,38 @@
+package sloghandler
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func (h *logHandler) getFilePath(path string) []byte {
+	cacheKey := fmt.Sprintf("%s:%d", path, h.opts.SourceDepth)
+	if cached, ok := h.sourceCache.Load(cacheKey); ok {
+		return cached.([]byte)
+	}
+
+	depth := h.opts.SourceDepth
+	if depth < 0 {
+		depth = 0 // Default to 0 if negative
+	}
+
+	if depth == 0 {
+		// Show only filename
+		result := []byte(filepath.Base(path))
+		h.sourceCache.Store(cacheKey, result)
+		return result
+	}
+
+	// Build path with specified depth
+	parts := []string{filepath.Base(path)} // Start with filename
+	currentPath := filepath.Dir(path)
+
+	for i := 0; i < depth && currentPath != "." && currentPath != string(filepath.Separator) && currentPath != "" && filepath.Dir(currentPath) != currentPath; i++ {
+		parts = append([]string{filepath.Base(currentPath)}, parts...)
+		currentPath = filepath.Dir(currentPath)
+	}
+
+	result := []byte(filepath.Join(parts...))
+	h.sourceCache.Store(cacheKey, result)
+	return result
+}

--- a/source_go125.go
+++ b/source_go125.go
@@ -1,0 +1,16 @@
+//go:build go1.25
+
+package sloghandler
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+)
+
+func (h *logHandler) printSource(buf *bytes.Buffer, record slog.Record) {
+	if s := record.Source(); s != nil {
+		file := h.getFilePath(s.File)
+		fmt.Fprintf(buf, " [%s:%d]", file, s.Line)
+	}
+}

--- a/source_legacy.go
+++ b/source_legacy.go
@@ -1,0 +1,20 @@
+//go:build go1.23 && !go1.25
+
+package sloghandler
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"runtime"
+)
+
+func (h *logHandler) printSource(buf *bytes.Buffer, record slog.Record) {
+	if record.PC == 0 {
+		return
+	}
+	fs := runtime.CallersFrames([]uintptr{record.PC})
+	f, _ := fs.Next()
+	file := h.getFilePath(f.File)
+	fmt.Fprintf(buf, " [%s:%d]", file, f.Line)
+}


### PR DESCRIPTION
## Summary
- Add `Source` and `SourceDepth` options to `HandlerOptions` for displaying source file location in logs
- Support Go 1.25+ (`record.Source()`) and Go 1.23-1.24 (`runtime.CallersFrames`) with build tags
- Add path caching for performance optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)