### PR TITLE
Move per-record attributes after message in log output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,36 +1,52 @@
-# sloghandler
+# CLAUDE.md
 
-A collection of handlers for Go's `log/slog` package.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Structure
+## Project Overview
 
-- `main.go` - Main colored text log handler implementation
-- `source.go` - Source file path utility (shared)
-- `source_go125.go` - Go 1.25+ source location using `record.Source()`
-- `source_legacy.go` - Go 1.23-1.24 source location using `runtime.CallersFrames`
-- `otelmetrics/` - OpenTelemetry metrics handler (separate go.mod)
-- `prommetrics/` - Prometheus metrics handler (separate go.mod)
+A collection of handlers for Go's `log/slog` package. The root package provides a colored text log handler; subpackages provide metrics-collecting wrapper handlers for Prometheus and OpenTelemetry.
 
-## Development
+## Development Commands
 
 ```bash
-# Run tests
+# Run root package tests
 go test -v ./...
 
-# Run tests for subpackages
+# Run tests with race detector (as CI does)
+go test -race ./...
+
+# Run a single test
+go test -v -run TestHandlerOutput ./...
+
+# Subpackages have separate go.mod files — test them independently
 cd otelmetrics && go test -v ./...
 cd prommetrics && go test -v ./...
 ```
 
+## Architecture
+
+### Root package (`sloghandler`)
+
+`logHandler` implements `slog.Handler`. It writes colored, human-readable text logs to an `io.Writer`. Key design points:
+
+- **Color output**: Uses `github.com/fatih/color`. Colors are configured via package-level variables (`DebugColor`, `InfoColor`, etc.) and cached `FprintFunc` closures.
+- **Source location**: Uses build-tag-selected implementations — `source_go125.go` uses `record.Source()` (Go 1.25+), `source_legacy.go` uses `runtime.CallersFrames` (Go 1.23–1.24). Shared path formatting logic is in `source.go` with a `sync.Map` cache.
+- **Thread safety**: A shared `sync.Mutex` is used for writing; `WithAttrs()` returns a new handler sharing the same mutex and writer.
+
+### Metrics subpackages (`otelmetrics/`, `prommetrics/`)
+
+Both follow the same wrapper-handler pattern: they embed `slog.Handler`, intercept `Handle()` to increment a counter by log level, then delegate to the base handler. Both support `Options` with `MinLevel` and `LabelAttributes` for custom metric labels.
+
+These are **independent Go modules** with their own `go.mod` — they cannot import or be imported by the root module directly.
+
 ## Build Tags
 
-- `//go:build go1.25` - For Go 1.25+ specific code
-- `//go:build go1.23 && !go1.25` - For Go 1.23-1.24 specific code
+- `//go:build go1.25` — Go 1.25+ specific code
+- `//go:build go1.23 && !go1.25` — Go 1.23–1.24 specific code
 
-## Notes
+## CI
 
-- Subpackages (`otelmetrics/`, `prommetrics/`) have their own `go.mod` files
-- CI tests against Go 1.23, 1.24, and 1.25
+CI runs `go test -race ./...` against Go 1.23, 1.24, and 1.25. Subpackage tests are not in CI matrix (they have separate modules).
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Output format:
 2023-05-09T12:34:56.790+09:00 [INFO] This is an info message
 2023-05-09T12:34:56.791+09:00 [WARN] This is a warning message
 2023-05-09T12:34:56.792+09:00 [ERROR] This is an error message
-2023-05-09T12:34:56.793+09:00 [INFO] [port:8080] [environment:production] Server started
+2023-05-09T12:34:56.793+09:00 [INFO] Server started [port:8080] [environment:production]
 2023-05-09T12:34:56.794+09:00 [INFO] [component:server] [id:main] Listening for connections
 ```
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -60,7 +60,7 @@ func TestNewLogger(t *testing.T) {
 
 	logger.Info("test message", "", "extra", "key", 42)
 	output := buf.String()
-	if !bytes.Contains(buf.Bytes(), []byte("[INFO] [foo] [bar:baz] [handler_test.go:61] [extra] [key:42] test message")) {
+	if !bytes.Contains(buf.Bytes(), []byte("[INFO] [foo] [bar:baz] [handler_test.go:61] test message [extra] [key:42]")) {
 		t.Errorf("Logger output doesn't contain message, got: %s", output)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -111,6 +111,8 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 		h.printSource(buf, record)
 	}
 
+	fmt.Fprintf(buf, " %s", record.Message)
+
 	record.Attrs(func(a slog.Attr) bool {
 		if a.Key == "" {
 			fmt.Fprintf(buf, " [%v]", a.Value)
@@ -120,7 +122,7 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 		return true
 	})
 
-	fmt.Fprintf(buf, " %s\n", record.Message)
+	buf.WriteByte('\n')
 
 	// Apply color only once at the end if needed
 	h.mu.Lock()


### PR DESCRIPTION
## Summary

- Per-record attributes (passed in individual log calls) are now placed after the message for readability
- `With()` attributes remain before the message, as they represent important shared context

```
# Before
2023-05-09T12:34:56.793+09:00 [INFO] [port:8080] [environment:production] Server started

# After
2023-05-09T12:34:56.793+09:00 [INFO] Server started [port:8080] [environment:production]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)