### PR TITLE
Deprecate HandlerOptions.Source in favor of AddSource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ Both follow the same wrapper-handler pattern: they embed `slog.Handler`, interce
 
 These are **independent Go modules** with their own `go.mod` — they cannot import or be imported by the root module directly.
 
+## TODO for v1
+
+- Remove deprecated `HandlerOptions.Source` field and related backward-compatibility logic in `Handle()`. Use `slog.HandlerOptions.AddSource` only. Also remove `TestDeprecatedSourceField` test.
+
 ## CI
 
 CI runs `go test -race ./...` against Go 1.25 and 1.26. Subpackage tests are not in CI matrix (they have separate modules).

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ You can display source file location (filename and line number) in log output:
 ```go
 opts := &sloghandler.HandlerOptions{
 	HandlerOptions: slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level:     slog.LevelDebug,
+		AddSource: true,   // Enable source file display
 	},
-	Source: true,      // Enable source file display
 	SourceDepth: 1,    // Include parent directory (e.g., "pkg/main.go")
 }
 handler := sloghandler.NewLogHandler(os.Stdout, opts)

--- a/handler_test.go
+++ b/handler_test.go
@@ -50,17 +50,38 @@ func TestNewLogger(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := io.MultiWriter(buf, os.Stderr)
 	opts := &HandlerOptions{
-		HandlerOptions: slog.HandlerOptions{Level: slog.LevelInfo},
-		Color:          false,
-		Source:         true,
+		HandlerOptions: slog.HandlerOptions{
+			Level:     slog.LevelInfo,
+			AddSource: true,
+		},
+		Color: false,
 	}
 	logger := slog.New(NewLogHandler(w, opts))
 	logger = logger.With("", "foo", "bar", "baz")
 
 	logger.Info("test message", "", "extra", "key", 42)
 	output := buf.String()
-	if !bytes.Contains(buf.Bytes(), []byte("[INFO] [foo] [bar:baz] [handler_test.go:60] test message [extra] [key:42]")) {
-		t.Errorf("Logger output doesn't contain message, got: %s", output)
+	if !bytes.Contains(buf.Bytes(), []byte("[INFO] [foo] [bar:baz] [handler_test.go:")) {
+		t.Errorf("Logger output doesn't contain message with source, got: %s", output)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("test message [extra] [key:42]")) {
+		t.Errorf("Logger output doesn't contain message with attrs, got: %s", output)
+	}
+}
+
+func TestDeprecatedSourceField(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := io.MultiWriter(buf, os.Stderr)
+	opts := &HandlerOptions{
+		HandlerOptions: slog.HandlerOptions{Level: slog.LevelInfo},
+		Color:          false,
+		Source:         true, // deprecated field should still work
+	}
+	logger := slog.New(NewLogHandler(w, opts))
+	logger.Info("deprecated source test")
+	output := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("[handler_test.go:")) {
+		t.Errorf("Deprecated Source field should still enable source output, got: %s", output)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,9 @@ type HandlerOptions struct {
 	slog.HandlerOptions
 	// Color enables colored output based on log level when set to true.
 	// Colors can be customized using the global color variables.
-	Color  bool
+	Color bool
+	// Deprecated: Use slog.HandlerOptions.AddSource instead.
+	// TODO: Remove this field in v1.
 	Source bool
 	// SourceDepth controls the number of parent directories to include in source file paths.
 	// Default is 0 (filename only). Set to 1 for parent/file.go, 2 for grandparent/parent/file.go, etc.
@@ -107,7 +109,7 @@ func (h *logHandler) Handle(ctx context.Context, record slog.Record) error {
 		buf.Write(h.preformatted)
 	}
 
-	if h.opts.Source {
+	if h.opts.Source || h.opts.AddSource {
 		h.printSource(buf, record)
 	}
 


### PR DESCRIPTION
## Summary
- Deprecate `HandlerOptions.Source` field in favor of the standard `slog.HandlerOptions.AddSource`
- Both fields work for backward compatibility; `Source` will be removed in v1
- Update tests and README to use `AddSource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)